### PR TITLE
修正设置页面 『自动获取 Bot 名称』 功能

### DIFF
--- a/Model/TelegramModel.class.php
+++ b/Model/TelegramModel.class.php
@@ -202,7 +202,7 @@
         public function getMe () {
             $this->ret = $this->callMethod ('getMe', [
             ]);
-            return $this->ret['result'];
+            return $this->ret;
         }
         public function getStickerSet ($name) {
             $this->ret = $this->callMethod ('getStickerSet', [


### PR DESCRIPTION
原因为 `Settings.class.php` 内所判断的 `ok` 元素被 `getMe` 函数返回前丢弃